### PR TITLE
Initial scheduler implementation

### DIFF
--- a/kv/engine_util/engines.go
+++ b/kv/engine_util/engines.go
@@ -2,6 +2,9 @@ package engine_util
 
 import (
 	"github.com/coocood/badger"
+	"github.com/ngaut/log"
+	"github.com/pingcap-incubator/tinykv/kv/config"
+	"path/filepath"
 )
 
 // Engines keeps references to and data for the engines used by unistore.
@@ -42,4 +45,31 @@ func (en *Engines) SyncKVWAL() error {
 func (en *Engines) SyncRaftWAL() error {
 	// TODO: implement
 	return nil
+}
+
+// CreateDB creates a new Badger DB on disk at subPath.
+func CreateDB(subPath string, conf *config.Engine) *badger.DB {
+	opts := badger.DefaultOptions
+	opts.NumCompactors = conf.NumCompactors
+	opts.ValueThreshold = conf.ValueThreshold
+	if subPath == "raft" {
+		// Do not need to write blob for raft engine because it will be deleted soon.
+		opts.ValueThreshold = 0
+	}
+	opts.ValueLogWriteOptions.WriteBufferSize = 4 * 1024 * 1024
+	opts.Dir = filepath.Join(conf.DBPath, subPath)
+	opts.ValueDir = opts.Dir
+	opts.ValueLogFileSize = conf.VlogFileSize
+	opts.MaxTableSize = conf.MaxTableSize
+	opts.NumMemtables = conf.NumMemTables
+	opts.NumLevelZeroTables = conf.NumL0Tables
+	opts.NumLevelZeroTablesStall = conf.NumL0TablesStall
+	opts.SyncWrites = conf.SyncWrite
+	opts.MaxCacheSize = conf.BlockCacheSize
+	opts.TableBuilderOptions.SuRFStartLevel = conf.SurfStartLevel
+	db, err := badger.Open(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return db
 }

--- a/kv/tikv/errors.go
+++ b/kv/tikv/errors.go
@@ -173,7 +173,7 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 }
 
 func convertToPBError(err error) (*kvrpcpb.KeyError, *errorpb.Error) {
-	if regErr := extractRegionError(err); regErr != nil {
+	if regErr := ExtractRegionError(err); regErr != nil {
 		return nil, regErr
 	}
 	return convertToKeyError(err), nil
@@ -181,7 +181,7 @@ func convertToPBError(err error) (*kvrpcpb.KeyError, *errorpb.Error) {
 
 func convertToPBErrors(err error) ([]*kvrpcpb.KeyError, *errorpb.Error) {
 	if err != nil {
-		if regErr := extractRegionError(err); regErr != nil {
+		if regErr := ExtractRegionError(err); regErr != nil {
 			return nil, regErr
 		}
 		return []*kvrpcpb.KeyError{convertToKeyError(err)}, nil
@@ -189,7 +189,7 @@ func convertToPBErrors(err error) ([]*kvrpcpb.KeyError, *errorpb.Error) {
 	return nil, nil
 }
 
-func extractRegionError(err error) *errorpb.Error {
+func ExtractRegionError(err error) *errorpb.Error {
 	if regionError, ok := err.(*inner_server.RegionError); ok {
 		return regionError.RequestErr
 	}

--- a/kv/tikv/errors.go
+++ b/kv/tikv/errors.go
@@ -2,6 +2,10 @@ package tikv
 
 import (
 	"fmt"
+	"github.com/juju/errors"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/inner_server"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/errorpb"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
 )
 
 // ErrLocked is returned when trying to Read/Write on a locked key. Client should
@@ -97,4 +101,97 @@ type ErrTxnNotFound struct {
 
 func (e *ErrTxnNotFound) Error() string {
 	return "txn not found"
+}
+
+func convertToKeyError(err error) *kvrpcpb.KeyError {
+	if err == nil {
+		return nil
+	}
+	causeErr := errors.Cause(err)
+	switch x := causeErr.(type) {
+	case *ErrLocked:
+		return &kvrpcpb.KeyError{
+			Locked: &kvrpcpb.LockInfo{
+				Key:         x.Key,
+				PrimaryLock: x.Primary,
+				LockVersion: x.StartTS,
+				LockTtl:     x.TTL,
+			},
+		}
+	case ErrRetryable:
+		return &kvrpcpb.KeyError{
+			Retryable: x.Error(),
+		}
+	case *ErrKeyAlreadyExists:
+		return &kvrpcpb.KeyError{
+			AlreadyExist: &kvrpcpb.AlreadyExist{
+				Key: x.Key,
+			},
+		}
+	case *ErrConflict:
+		return &kvrpcpb.KeyError{
+			Conflict: &kvrpcpb.WriteConflict{
+				StartTs:          x.StartTS,
+				ConflictTs:       x.ConflictTS,
+				ConflictCommitTs: x.ConflictCommitTS,
+				Key:              x.Key,
+			},
+		}
+	case *ErrDeadlock:
+		return &kvrpcpb.KeyError{
+			Deadlock: &kvrpcpb.Deadlock{
+				LockKey:         x.LockKey,
+				LockTs:          x.LockTS,
+				DeadlockKeyHash: x.DeadlockKeyHash,
+			},
+		}
+	case *ErrCommitExpire:
+		return &kvrpcpb.KeyError{
+			CommitTsExpired: &kvrpcpb.CommitTsExpired{
+				StartTs:           x.StartTs,
+				AttemptedCommitTs: x.CommitTs,
+				Key:               x.Key,
+				MinCommitTs:       x.MinCommitTs,
+			},
+		}
+	case *ErrTxnNotFound:
+		return &kvrpcpb.KeyError{
+			TxnNotFound: &kvrpcpb.TxnNotFound{
+				StartTs:    x.StartTS,
+				PrimaryKey: x.PrimaryKey,
+			},
+		}
+	case *ErrCommitPessimisticLock:
+		return &kvrpcpb.KeyError{
+			Abort: x.Error(),
+		}
+	default:
+		return &kvrpcpb.KeyError{
+			Abort: err.Error(),
+		}
+	}
+}
+
+func convertToPBError(err error) (*kvrpcpb.KeyError, *errorpb.Error) {
+	if regErr := extractRegionError(err); regErr != nil {
+		return nil, regErr
+	}
+	return convertToKeyError(err), nil
+}
+
+func convertToPBErrors(err error) ([]*kvrpcpb.KeyError, *errorpb.Error) {
+	if err != nil {
+		if regErr := extractRegionError(err); regErr != nil {
+			return nil, regErr
+		}
+		return []*kvrpcpb.KeyError{convertToKeyError(err)}, nil
+	}
+	return nil, nil
+}
+
+func extractRegionError(err error) *errorpb.Error {
+	if regionError, ok := err.(*inner_server.RegionError); ok {
+		return regionError.RequestErr
+	}
+	return nil
 }

--- a/kv/tikv/inner_server/mem_server.go
+++ b/kv/tikv/inner_server/mem_server.go
@@ -1,0 +1,58 @@
+package inner_server
+
+import (
+	"github.com/pingcap-incubator/tinykv/kv/engine_util"
+	"github.com/pingcap-incubator/tinykv/kv/pd"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/dbreader"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/tikvpb"
+)
+
+// MemInnerServer is a simple inner server backed by memory for testing. Data is not written to disk, nor sent to other
+// nodes. It is intended for testing only.
+type MemInnerServer struct {
+	Data map[byte][]byte
+}
+
+func NewMemInnerServer() *MemInnerServer {
+	return &MemInnerServer{
+		Data: make(map[byte][]byte),
+	}
+}
+
+func (is *MemInnerServer) Raft(stream tikvpb.Tikv_RaftServer) error {
+	return nil
+}
+
+func (is *MemInnerServer) Snapshot(stream tikvpb.Tikv_SnapshotServer) error {
+	return nil
+}
+
+func (is *MemInnerServer) Start(pdClient pd.Client) error {
+	return nil
+}
+
+func (is *MemInnerServer) Stop() error {
+	return nil
+}
+
+func (is *MemInnerServer) Reader(ctx *kvrpcpb.Context) (dbreader.DBReader, error) {
+	return &memReader{is}, nil
+}
+
+func (is *MemInnerServer) Write(ctx *kvrpcpb.Context, batch []Modify) error {
+	return nil
+}
+
+// memReader is a DBReader which reads from a MemInnerServer.
+type memReader struct {
+	inner *MemInnerServer
+}
+
+func (mr *memReader) GetCF(cf string, key []byte) ([]byte, error) {
+	return mr.inner.Data[key[0]], nil
+}
+
+func (mr *memReader) IterCF(cf string) *engine_util.CFIterator {
+	return nil
+}

--- a/kv/tikv/inner_server/modify.go
+++ b/kv/tikv/inner_server/modify.go
@@ -1,5 +1,6 @@
 package inner_server
 
+// ModifyType is the smallest unit of mutation of TinyKV's underlying storage (i.e., raw key/values on disk(s))
 type ModifyType int64
 
 const (

--- a/kv/tikv/inner_server/raft_server.go
+++ b/kv/tikv/inner_server/raft_server.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 )
 
+// RaftInnerServer is an InnerServer (see tikv/server.go) backed by a Raft node. It is part of a Raft network.
+// By using Raft, reads and writes are consistent with other nodes in the TinyKV instance.
 type RaftInnerServer struct {
 	engines    *engine_util.Engines
 	raftConfig *config.Config

--- a/kv/tikv/inner_server/standalone_server.go
+++ b/kv/tikv/inner_server/standalone_server.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pingcap-incubator/tinykv/proto/pkg/tikvpb"
 )
 
+// StandAloneInnerServer is an InnerServer (see tikv/server.go) for a single-node TinyKV instance. It does not
+// communicate with other nodes and all data is stored locally.
 type StandAloneInnerServer struct {
 	db *badger.DB
 }

--- a/kv/tikv/inner_server/standalone_server.go
+++ b/kv/tikv/inner_server/standalone_server.go
@@ -2,6 +2,8 @@ package inner_server
 
 import (
 	"github.com/coocood/badger"
+	kvConfig "github.com/pingcap-incubator/tinykv/kv/config"
+	"github.com/pingcap-incubator/tinykv/kv/engine_util"
 	"github.com/pingcap-incubator/tinykv/kv/pd"
 	"github.com/pingcap-incubator/tinykv/kv/tikv/dbreader"
 	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
@@ -12,7 +14,8 @@ type StandAloneInnerServer struct {
 	db *badger.DB
 }
 
-func NewStandAloneInnerServer(db *badger.DB) *StandAloneInnerServer {
+func NewStandAloneInnerServer(conf *kvConfig.Config) *StandAloneInnerServer {
+	db := engine_util.CreateDB("kv", &conf.Engine)
 	return &StandAloneInnerServer{
 		db: db,
 	}
@@ -25,8 +28,6 @@ func (is *StandAloneInnerServer) Raft(stream tikvpb.Tikv_RaftServer) error {
 func (is *StandAloneInnerServer) Snapshot(stream tikvpb.Tikv_SnapshotServer) error {
 	return nil
 }
-
-func (is *StandAloneInnerServer) Setup(pdClient pd.Client) {}
 
 func (is *StandAloneInnerServer) Start(pdClient pd.Client) error {
 	return nil

--- a/kv/tikv/inner_server/standalone_server.go
+++ b/kv/tikv/inner_server/standalone_server.go
@@ -8,38 +8,38 @@ import (
 	"github.com/pingcap-incubator/tinykv/proto/pkg/tikvpb"
 )
 
-type StandAlongInnerServer struct {
+type StandAloneInnerServer struct {
 	db *badger.DB
 }
 
-func NewStandAlongInnerServer(db *badger.DB) *StandAlongInnerServer {
-	return &StandAlongInnerServer{
+func NewStandAloneInnerServer(db *badger.DB) *StandAloneInnerServer {
+	return &StandAloneInnerServer{
 		db: db,
 	}
 }
 
-func (is *StandAlongInnerServer) Raft(stream tikvpb.Tikv_RaftServer) error {
+func (is *StandAloneInnerServer) Raft(stream tikvpb.Tikv_RaftServer) error {
 	return nil
 }
 
-func (is *StandAlongInnerServer) Snapshot(stream tikvpb.Tikv_SnapshotServer) error {
+func (is *StandAloneInnerServer) Snapshot(stream tikvpb.Tikv_SnapshotServer) error {
 	return nil
 }
 
-func (is *StandAlongInnerServer) Setup(pdClient pd.Client) {}
+func (is *StandAloneInnerServer) Setup(pdClient pd.Client) {}
 
-func (is *StandAlongInnerServer) Start(pdClient pd.Client) error {
+func (is *StandAloneInnerServer) Start(pdClient pd.Client) error {
 	return nil
 }
 
-func (is *StandAlongInnerServer) Stop() error {
+func (is *StandAloneInnerServer) Stop() error {
 	return is.db.Close()
 }
 
-func (is *StandAlongInnerServer) Reader(ctx *kvrpcpb.Context) (dbreader.DBReader, error) {
+func (is *StandAloneInnerServer) Reader(ctx *kvrpcpb.Context) (dbreader.DBReader, error) {
 	return nil, nil
 }
 
-func (is *StandAlongInnerServer) Write(ctx *kvrpcpb.Context, batch []Modify) error {
+func (is *StandAloneInnerServer) Write(ctx *kvrpcpb.Context, batch []Modify) error {
 	return nil
 }

--- a/kv/tikv/storage/commands/raw.go
+++ b/kv/tikv/storage/commands/raw.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"github.com/coocood/badger"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/kvstore"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/errorpb"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
+)
+
+// RawGet implements the Command interface for raw get requests.
+type RawGet struct {
+	request  *kvrpcpb.RawGetRequest
+	response kvrpcpb.RawGetResponse
+}
+
+func NewRawGet(request *kvrpcpb.RawGetRequest) RawGet {
+	return RawGet{request, kvrpcpb.RawGetResponse{}}
+}
+
+func (rg *RawGet) BuildTxn(txn *kvstore.Txn) error {
+	val, err := txn.Reader.GetCF(rg.request.Cf, rg.request.Key)
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			rg.response.NotFound = true
+		} else {
+			return err
+		}
+	} else {
+		rg.response.Value = val
+	}
+	return nil
+}
+
+func (rg *RawGet) Context() *kvrpcpb.Context {
+	return rg.request.Context
+}
+
+func (rg *RawGet) Response() (interface{}, error) {
+	return &rg.response, nil
+}
+
+func (rg *RawGet) RegionError(err *errorpb.Error) interface{} {
+	if err == nil {
+		return nil
+	}
+
+	rg.response.RegionError = err
+	return &rg.response
+}

--- a/kv/tikv/storage/doc.go
+++ b/kv/tikv/storage/doc.go
@@ -1,0 +1,23 @@
+package storage
+
+// The storage package implements TinyKV's 'transaction' layer. This takes incoming requests from the tikv/server.go as
+// input and turns them into reads and writes of the underlying key/value store (defined by InnerServer in tikv/server.go).
+// The InnerServer handles communicating with other nodes and writing data to disk. The transaction layer must
+// translate high-level TinyKV commands into low-level raw key/value commands, schedule this processing to run efficiently,
+// and ensure that processing of commands do not interfere with processing other commands.
+//
+// Note that there are two kinds of transactions in play: TinySQL transactions are collaborative between TinyKV and its
+// client (e.g., TinySQL). They are implemented using multiple TinyKV commands and ensure that multiple SQL commands can
+// be executed atomically. There are also internal transactions which are an implementation detail of this
+// layer in TinyKV (represented by Txn in tikv/storage/exec/transaction.go). These ensure that a *single* TinyKV command
+// is executed atomically.
+//
+// *Locks* are used to implement TinySQL transactions. Setting or checking a lock in a TinySQL transaction is lowered to
+// writing or reading a key and value in the InnerServer store. TODO explain this encoding in detail.
+//
+// *Latches* are used to implement internal transactions and are not visible to the client. They are stored outside the
+// underlying storage (or equivalently, you can think of every key having its own latch). TODO explain latching in more detail.
+//
+// Within this package, `commands` contains code to lower TinySQL requests to internal transactions. `exec` contains
+// code to handle scheduling and running commands. `kvstore` contains code for interacting with the underlying storage
+// (InnerServer).

--- a/kv/tikv/storage/exec/scheduler.go
+++ b/kv/tikv/storage/exec/scheduler.go
@@ -1,0 +1,72 @@
+package exec
+
+import (
+	"github.com/pingcap-incubator/tinykv/kv/tikv"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/kvstore"
+)
+
+// Sequential is a Scheduler which executes all commands sequentially on a single thread. Since there is no concurrency,
+// no latching, etc. is required.
+type Sequential struct {
+	innerServer tikv.InnerServer
+	queue       chan task
+}
+
+type task struct {
+	cmd           tikv.Command
+	resultChannel chan<- tikv.RespResult
+}
+
+func NewSeqScheduler(innerServer tikv.InnerServer) *Sequential {
+	sched := &Sequential{innerServer, make(chan task)}
+	go sched.handleTask()
+	return sched
+}
+
+func (seq *Sequential) handleTask() {
+	for {
+		task := <-seq.queue
+
+		if task.cmd == nil && task.resultChannel == nil {
+			close(seq.queue)
+			return
+		}
+
+		reader, err := seq.innerServer.Reader(task.cmd.Context())
+		if err != nil {
+			if regResp := task.cmd.RegionError(tikv.ExtractRegionError(err)); regResp != nil {
+				task.resultChannel <- tikv.RespOk(regResp)
+			} else {
+				task.resultChannel <- tikv.RespErr(err)
+			}
+		}
+
+		txn := kvstore.NewTxn(reader)
+		err = task.cmd.BuildTxn(&txn)
+		if err != nil {
+			task.resultChannel <- tikv.RespErr(err)
+		}
+
+		// TODO exectute txn
+
+		result, err := task.cmd.Response()
+		if err != nil {
+			task.resultChannel <- tikv.RespErr(err)
+		}
+
+		task.resultChannel <- tikv.RespOk(result)
+
+		close(task.resultChannel)
+	}
+}
+
+func (seq *Sequential) Stop() {
+	seq.queue <- task{nil, nil}
+}
+
+func (seq *Sequential) Run(cmd tikv.Command) <-chan tikv.RespResult {
+	channel := make(chan tikv.RespResult, 1)
+	tsk := task{cmd, channel}
+	seq.queue <- tsk
+	return channel
+}

--- a/kv/tikv/storage/exec/scheduler_test.go
+++ b/kv/tikv/storage/exec/scheduler_test.go
@@ -1,0 +1,48 @@
+package exec
+
+import (
+	"github.com/pingcap-incubator/tinykv/kv/tikv"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/inner_server"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/kvstore"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/errorpb"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+// TestSeqScheduled tests that the sequential scheduler schedules multiple commands sent to it and returns the results
+// in order.
+func TestSeqScheduled(t *testing.T) {
+	seq := NewSeqScheduler(inner_server.NewMemInnerServer())
+	var chs []<-chan tikv.RespResult
+	for i := 0; i < 6; i++ {
+		chs = append(chs, seq.Run(&dummyCmd{i}))
+	}
+
+	for i, ch := range chs {
+		r := <-ch
+		assert.Equal(t, r.Response.(int), i)
+	}
+	seq.Stop()
+}
+
+type dummyCmd struct {
+	id int
+}
+
+func (dc *dummyCmd) BuildTxn(txn *kvstore.Txn) error {
+	return nil
+}
+
+func (dc *dummyCmd) Context() *kvrpcpb.Context {
+	return nil
+}
+
+func (dc *dummyCmd) Response() (interface{}, error) {
+	return dc.id, nil
+}
+
+func (dc *dummyCmd) RegionError(err *errorpb.Error) interface{} {
+	return nil
+}

--- a/kv/tikv/storage/kvstore/transaction.go
+++ b/kv/tikv/storage/kvstore/transaction.go
@@ -1,0 +1,20 @@
+package kvstore
+
+import (
+	"github.com/pingcap-incubator/tinykv/kv/tikv/dbreader"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/inner_server"
+)
+
+// Txn represents an internal transaction (see tikv/storage/doc.go for a definition). It permits reading from a snapshot
+// and stores writes in a buffer for atomic writing.
+type Txn struct {
+	Reader dbreader.DBReader
+	Writes []inner_server.Modify
+}
+
+func NewTxn(reader dbreader.DBReader) Txn {
+	return Txn{
+		reader,
+		nil,
+	}
+}

--- a/kv/tikv/storage/raw_test.go
+++ b/kv/tikv/storage/raw_test.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"github.com/pingcap-incubator/tinykv/kv/tikv/inner_server"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/commands"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/exec"
+	"github.com/pingcap-incubator/tinykv/proto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	mem := inner_server.NewMemInnerServer()
+	mem.Data[99] = []byte{42}
+	sched := exec.NewSeqScheduler(mem)
+
+	var req kvrpcpb.RawGetRequest
+	req.Key = []byte{99}
+	req.Cf = "default"
+	get := commands.NewRawGet(&req)
+
+	ch := sched.Run(&get)
+	result := <-ch
+	sched.Stop()
+
+	assert.Nil(t, result.Err)
+	resp := result.Response.(*kvrpcpb.RawGetResponse)
+	assert.Equal(t, resp.Value, []byte{42})
+}

--- a/kv/tinykv-server/main.go
+++ b/kv/tinykv-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"github.com/pingcap-incubator/tinykv/kv/tikv/storage/exec"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -67,7 +68,8 @@ func main() {
 	} else {
 		innerServer = setupStandAloneInnerServer(pdClient, conf)
 	}
-	tikvServer := tikv.NewServer(innerServer)
+	scheduler := exec.NewSeqScheduler(innerServer)
+	tikvServer := tikv.NewServer(innerServer, scheduler)
 
 	var alivePolicy = keepalive.EnforcementPolicy{
 		MinTime:             2 * time.Second, // If a client pings more than once every 2 seconds, terminate the connection

--- a/kv/tinykv-server/main.go
+++ b/kv/tinykv-server/main.go
@@ -74,7 +74,7 @@ func main() {
 	if conf.Server.Raft {
 		innerServer = setupRaftInnerServer(db, pdClient, conf)
 	} else {
-		innerServer = setupStandAlongInnerServer(db, pdClient, conf)
+		innerServer = setupStandAloneInnerServer(db, pdClient, conf)
 	}
 	tikvServer := tikv.NewServer(innerServer)
 
@@ -181,8 +181,8 @@ func setupRaftInnerServer(kvDB *badger.DB, pdClient pd.Client, conf *config.Conf
 	return innerServer
 }
 
-func setupStandAlongInnerServer(db *badger.DB, pdClient pd.Client, conf *config.Config) tikv.InnerServer {
-	innerServer := inner_server.NewStandAlongInnerServer(db)
+func setupStandAloneInnerServer(db *badger.DB, pdClient pd.Client, conf *config.Config) tikv.InnerServer {
+	innerServer := inner_server.NewStandAloneInnerServer(db)
 	innerServer.Setup(pdClient)
 
 	if err := innerServer.Start(pdClient); err != nil {

--- a/kv/tinykv-server/main.go
+++ b/kv/tinykv-server/main.go
@@ -7,7 +7,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -18,10 +17,8 @@ import (
 	"github.com/coocood/badger/y"
 	"github.com/ngaut/log"
 	"github.com/pingcap-incubator/tinykv/kv/config"
-	"github.com/pingcap-incubator/tinykv/kv/engine_util"
 	"github.com/pingcap-incubator/tinykv/kv/pd"
 	"github.com/pingcap-incubator/tinykv/kv/tikv"
-	tikvConf "github.com/pingcap-incubator/tinykv/kv/tikv/config"
 	"github.com/pingcap-incubator/tinykv/kv/tikv/inner_server"
 	"github.com/pingcap-incubator/tinykv/proto/pkg/tikvpb"
 	"google.golang.org/grpc"
@@ -41,9 +38,6 @@ var (
 const (
 	grpcInitialWindowSize     = 1 << 30
 	grpcInitialConnWindowSize = 1 << 30
-
-	subPathRaft = "raft"
-	subPathKV   = "kv"
 )
 
 func main() {
@@ -61,20 +55,17 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 	log.Infof("conf %v", conf)
 	config.SetGlobalConf(conf)
-	db := createDB(subPathKV, &conf.Engine)
 
 	pdClient, err := pd.NewClient(strings.Split(conf.Server.PDAddr, ","), "")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var (
-		innerServer tikv.InnerServer
-	)
+	var innerServer tikv.InnerServer
 	if conf.Server.Raft {
-		innerServer = setupRaftInnerServer(db, pdClient, conf)
+		innerServer = setupRaftInnerServer(pdClient, conf)
 	} else {
-		innerServer = setupStandAloneInnerServer(db, pdClient, conf)
+		innerServer = setupStandAloneInnerServer(pdClient, conf)
 	}
 	tikvServer := tikv.NewServer(innerServer)
 
@@ -110,23 +101,11 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	tikvServer.Stop()
-	log.Info("Server stopped.")
-
-	// err = store.Close()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	// log.Info("Store closed.")
-
-	// if err = regionManager.Close(); err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	err = innerServer.Stop()
+	err = tikvServer.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
+	log.Info("Server stopped.")
 }
 
 func loadConfig() *config.Config {
@@ -141,39 +120,8 @@ func loadConfig() *config.Config {
 	return &conf
 }
 
-func setupRaftStoreConf(raftConf *tikvConf.Config, conf *config.Config) {
-	raftConf.Addr = conf.Server.StoreAddr
-	raftConf.RaftWorkerCnt = conf.RaftStore.RaftWorkers
-
-	// raftstore block
-	raftConf.PdHeartbeatTickInterval = config.ParseDuration(conf.RaftStore.PdHeartbeatTickInterval)
-	raftConf.RaftStoreMaxLeaderLease = config.ParseDuration(conf.RaftStore.RaftStoreMaxLeaderLease)
-	raftConf.RaftBaseTickInterval = config.ParseDuration(conf.RaftStore.RaftBaseTickInterval)
-	raftConf.RaftHeartbeatTicks = conf.RaftStore.RaftHeartbeatTicks
-	raftConf.RaftElectionTimeoutTicks = conf.RaftStore.RaftElectionTimeoutTicks
-}
-
-func setupRaftInnerServer(kvDB *badger.DB, pdClient pd.Client, conf *config.Config) tikv.InnerServer {
-	dbPath := conf.Engine.DBPath
-	kvPath := filepath.Join(dbPath, "kv")
-	raftPath := filepath.Join(dbPath, "raft")
-	snapPath := filepath.Join(dbPath, "snap")
-
-	os.MkdirAll(kvPath, os.ModePerm)
-	os.MkdirAll(raftPath, os.ModePerm)
-	os.Mkdir(snapPath, os.ModePerm)
-
-	raftConf := tikvConf.NewDefaultConfig()
-	raftConf.SnapPath = snapPath
-	setupRaftStoreConf(raftConf, conf)
-
-	raftDB := createDB(subPathRaft, &conf.Engine)
-
-	engines := engine_util.NewEngines(kvDB, raftDB, kvPath, raftPath)
-
-	innerServer := inner_server.NewRaftInnerServer(engines, raftConf)
-	innerServer.Setup(pdClient)
-
+func setupRaftInnerServer(pdClient pd.Client, conf *config.Config) tikv.InnerServer {
+	innerServer := inner_server.NewRaftInnerServer(conf)
 	if err := innerServer.Start(pdClient); err != nil {
 		log.Fatal(err)
 	}
@@ -181,41 +129,13 @@ func setupRaftInnerServer(kvDB *badger.DB, pdClient pd.Client, conf *config.Conf
 	return innerServer
 }
 
-func setupStandAloneInnerServer(db *badger.DB, pdClient pd.Client, conf *config.Config) tikv.InnerServer {
-	innerServer := inner_server.NewStandAloneInnerServer(db)
-	innerServer.Setup(pdClient)
-
+func setupStandAloneInnerServer(pdClient pd.Client, conf *config.Config) tikv.InnerServer {
+	innerServer := inner_server.NewStandAloneInnerServer(conf)
 	if err := innerServer.Start(pdClient); err != nil {
 		log.Fatal(err)
 	}
 
 	return innerServer
-}
-
-func createDB(subPath string, conf *config.Engine) *badger.DB {
-	opts := badger.DefaultOptions
-	opts.NumCompactors = conf.NumCompactors
-	opts.ValueThreshold = conf.ValueThreshold
-	if subPath == subPathRaft {
-		// Do not need to write blob for raft engine because it will be deleted soon.
-		opts.ValueThreshold = 0
-	}
-	opts.ValueLogWriteOptions.WriteBufferSize = 4 * 1024 * 1024
-	opts.Dir = filepath.Join(conf.DBPath, subPath)
-	opts.ValueDir = opts.Dir
-	opts.ValueLogFileSize = conf.VlogFileSize
-	opts.MaxTableSize = conf.MaxTableSize
-	opts.NumMemtables = conf.NumMemTables
-	opts.NumLevelZeroTables = conf.NumL0Tables
-	opts.NumLevelZeroTablesStall = conf.NumL0TablesStall
-	opts.SyncWrites = conf.SyncWrite
-	opts.MaxCacheSize = conf.BlockCacheSize
-	opts.TableBuilderOptions.SuRFStartLevel = conf.SurfStartLevel
-	db, err := badger.Open(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return db
 }
 
 func handleSignal(grpcServer *grpc.Server) {


### PR DESCRIPTION
This PR implements the start of the storage/transaction layer. Only raw get is refactored to the new system and the scheduler is very, very simple (see the message for the forth commit). There is also some preparatory refactoring in the earlier commits.

Obviously, this is a long way from a finished implementation, but I wanted to get some early feedback on my design and on my Go code.

PTAL @Connor1996 