### PR TITLE
fix:  assign error panic

### DIFF
--- a/kv/server/server.go
+++ b/kv/server/server.go
@@ -189,7 +189,7 @@ func rawRegionError(err error, resp interface{}) bool {
 	if err == nil {
 		return false
 	}
-	respValue := reflect.ValueOf(resp)
+	respValue := reflect.ValueOf(resp).Elem()
 	if regionErr, ok := err.(*raft_server.RegionError); ok {
 		respValue.FieldByName("RegionError").Set(reflect.ValueOf(regionErr.RequestErr))
 	} else {


### PR DESCRIPTION
Call to `server.rawRegionError` will cause "panic: reflect: call of reflect.Value.FieldByName on ptr Value".

Since the function seems not necessary to LAB1, so I haven't updated unit tests.