### PR TITLE
add the Value method for Modify type

### DIFF
--- a/kv/storage/modify.go
+++ b/kv/storage/modify.go
@@ -26,6 +26,14 @@ func (m *Modify) Key() []byte {
 	return nil
 }
 
+func (m *Modify) Value() []byte {
+	if putData, ok := m.Data.(Put); ok {
+		return putData.Value
+	}
+
+	return nil
+}
+
 func (m *Modify) Cf() string {
 	switch m.Data.(type) {
 	case Put:


### PR DESCRIPTION
## Why I want to add

When I implement the `Write` method of StandaloneStorage, I found I need a method that can help me get the value from the `modify.Data`. But there isn't a method called `Value()`(Because the `Key()` method existed)

Besides,  I think the `Delete` function doesn't need the Value. I just add this function for `Put`.