### PR TITLE
fix:  tinykv-server  argument db-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mkdir -p data
 ```
 
 ```
-./tinykv-server --db-path=data
+./tinykv-server -path=data
 ```
 
 ```


### PR DESCRIPTION
 fix  tinykv-server  argument  change `--db-path=data` to `-path=data`
 I run command
```sh
./tinykv-server --db-path=data
```
result:
```sh
flag provided but not defined: -db-path
Usage of ./tinykv-server:
  -addr string
        store address
  -loglevel string
        the level of log
  -path string
        directory path of db
  -scheduler string
        scheduler address
```