### PR TITLE
fix invalid order of expected and actual in kv/server/server_test.go

### DIFF
--- a/kv/raftstore/peer_storage_test.go
+++ b/kv/raftstore/peer_storage_test.go
@@ -75,9 +75,9 @@ func TestPeerStorageTerm(t *testing.T) {
 		peerStore := newTestPeerStorageFromEnts(t, ents)
 		term, err := peerStore.Term(tt.idx)
 		if err != nil {
-			assert.Equal(t, err, tt.err)
+			assert.Equal(t, tt.err, err)
 		} else {
-			assert.Equal(t, term, tt.term)
+			assert.Equal(t, tt.term, term)
 		}
 		cleanUpTestData(peerStore)
 	}

--- a/kv/raftstore/runner/runner_test.go
+++ b/kv/raftstore/runner/runner_test.go
@@ -194,7 +194,7 @@ func raftLogMustNotExist(t *testing.T, db *badger.DB, regionId, startIdx, endIdx
 		k := meta.RaftLogKey(regionId, i)
 		db.View(func(txn *badger.Txn) error {
 			_, err := txn.Get(k)
-			assert.Equal(t, err, badger.ErrKeyNotFound)
+			assert.Equal(t, badger.ErrKeyNotFound, err)
 			return nil
 		})
 	}
@@ -274,5 +274,5 @@ func TestSplitCheck(t *testing.T) {
 	msg := <-taskResCh
 	split, ok := msg.Data.(*message.MsgSplitRegion)
 	assert.True(t, ok)
-	assert.Equal(t, split.SplitKey, codec.EncodeBytes([]byte("k2")))
+	assert.Equal(t, codec.EncodeBytes([]byte("k2")), split.SplitKey)
 }

--- a/kv/raftstore/snap/snap_test.go
+++ b/kv/raftstore/snap/snap_test.go
@@ -119,9 +119,9 @@ func TestSnapGenMeta(t *testing.T) {
 	meta, err := genSnapshotMeta(cfFiles)
 	require.Nil(t, err)
 	for i, cfFileMeta := range meta.CfFiles {
-		assert.Equal(t, cfFileMeta.Cf, cfFiles[i].CF)
-		assert.Equal(t, cfFileMeta.Size_, cfFiles[i].Size)
-		assert.Equal(t, cfFileMeta.Checksum, cfFiles[i].Checksum)
+		assert.Equal(t, cfFiles[i].CF, cfFileMeta.Cf)
+		assert.Equal(t, cfFiles[i].Size, cfFileMeta.Size_)
+		assert.Equal(t, cfFiles[i].Checksum, cfFileMeta.Checksum)
 	}
 }
 
@@ -197,19 +197,19 @@ func doTestSnapFile(t *testing.T, dbHasData bool) {
 	// Ensure snapshot data could be read out of `s2`, and write into `s3`.
 	copySize, err := io.Copy(s3, s2)
 	require.Nil(t, err)
-	assert.Equal(t, copySize, size)
+	assert.Equal(t, size, copySize)
 	assert.False(t, s3.Exists())
 	assert.Nil(t, s3.Save())
 	assert.True(t, s3.Exists())
 
 	// Ensure the tracked size is handled correctly after receiving a snapshot.
-	assert.Equal(t, atomic.LoadInt64(sizeTrack), size*2)
+	assert.Equal(t, size*2, atomic.LoadInt64(sizeTrack))
 
 	// Ensure `delete()` works to delete the source snapshot.
 	s2.Delete()
 	assert.False(t, s2.Exists())
 	assert.False(t, s1.Exists())
-	assert.Equal(t, atomic.LoadInt64(sizeTrack), size)
+	assert.Equal(t, size, atomic.LoadInt64(sizeTrack))
 
 	// Ensure a snapshot could be applied to DB.
 	s4, err := NewSnapForApplying(dstDir, key, sizeTrack, deleter)
@@ -232,7 +232,7 @@ func doTestSnapFile(t *testing.T, dbHasData bool) {
 	s4.Delete()
 	assert.False(t, s4.Exists())
 	assert.False(t, s3.Exists())
-	assert.Equal(t, atomic.LoadInt64(sizeTrack), int64(0))
+	assert.Equal(t, int64(0), atomic.LoadInt64(sizeTrack))
 
 	// Verify the data is correct after applying snapshot.
 	if dbHasData {

--- a/kv/raftstore/util/error_test.go
+++ b/kv/raftstore/util/error_test.go
@@ -13,26 +13,26 @@ func TestRaftstoreErrToPbError(t *testing.T) {
 	notLeader := &ErrNotLeader{RegionId: regionId, Leader: nil}
 	pbErr := RaftstoreErrToPbError(notLeader)
 	require.NotNil(t, pbErr.NotLeader)
-	assert.Equal(t, pbErr.NotLeader.RegionId, regionId)
+	assert.Equal(t, regionId, pbErr.NotLeader.RegionId)
 
 	regionNotFound := &ErrRegionNotFound{RegionId: regionId}
 	pbErr = RaftstoreErrToPbError(regionNotFound)
 	require.NotNil(t, pbErr.RegionNotFound)
-	assert.Equal(t, pbErr.RegionNotFound.RegionId, regionId)
+	assert.Equal(t, regionId, pbErr.RegionNotFound.RegionId)
 
 	region := &metapb.Region{Id: regionId, StartKey: []byte{0}, EndKey: []byte{1}}
 
 	keyNotInRegion := &ErrKeyNotInRegion{Key: []byte{2}, Region: region}
 	pbErr = RaftstoreErrToPbError(keyNotInRegion)
 	require.NotNil(t, pbErr.KeyNotInRegion)
-	assert.Equal(t, pbErr.KeyNotInRegion.StartKey, []byte{0})
-	assert.Equal(t, pbErr.KeyNotInRegion.EndKey, []byte{1})
-	assert.Equal(t, pbErr.KeyNotInRegion.Key, []byte{2})
+	assert.Equal(t, []byte{0}, pbErr.KeyNotInRegion.StartKey)
+	assert.Equal(t, []byte{1}, pbErr.KeyNotInRegion.EndKey)
+	assert.Equal(t, []byte{2}, pbErr.KeyNotInRegion.Key)
 
 	epochNotMatch := &ErrEpochNotMatch{Regions: []*metapb.Region{region}}
 	pbErr = RaftstoreErrToPbError(epochNotMatch)
 	require.NotNil(t, pbErr.EpochNotMatch)
-	assert.Equal(t, pbErr.EpochNotMatch.CurrentRegions, []*metapb.Region{region})
+	assert.Equal(t, []*metapb.Region{region}, pbErr.EpochNotMatch.CurrentRegions)
 
 	staleCommand := &ErrStaleCommand{}
 	pbErr = RaftstoreErrToPbError(staleCommand)
@@ -42,6 +42,6 @@ func TestRaftstoreErrToPbError(t *testing.T) {
 	storeNotMatch := &ErrStoreNotMatch{RequestStoreId: requestStoreId, ActualStoreId: actualStoreId}
 	pbErr = RaftstoreErrToPbError(storeNotMatch)
 	require.NotNil(t, pbErr.StoreNotMatch)
-	assert.Equal(t, pbErr.StoreNotMatch.RequestStoreId, requestStoreId)
-	assert.Equal(t, pbErr.StoreNotMatch.ActualStoreId, actualStoreId)
+	assert.Equal(t, requestStoreId, pbErr.StoreNotMatch.RequestStoreId)
+	assert.Equal(t, actualStoreId, pbErr.StoreNotMatch.ActualStoreId)
 }

--- a/kv/raftstore/util/util_test.go
+++ b/kv/raftstore/util/util_test.go
@@ -35,11 +35,11 @@ func TestCheckKeyInRegion(t *testing.T) {
 		region.StartKey = c.StartKey
 		region.EndKey = c.EndKey
 		result := CheckKeyInRegion(c.Key, region)
-		assert.Equal(t, result == nil, c.IsInRegion)
+		assert.Equal(t, c.IsInRegion, result == nil)
 		result = CheckKeyInRegionInclusive(c.Key, region)
-		assert.Equal(t, result == nil, c.Inclusive)
+		assert.Equal(t, c.Inclusive, result == nil)
 		result = CheckKeyInRegionExclusive(c.Key, region)
-		assert.Equal(t, result == nil, c.Exclusive)
+		assert.Equal(t, c.Exclusive, result == nil)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestIsInitialMsg(t *testing.T) {
 		msg := new(eraftpb.Message)
 		msg.MsgType = m.MessageType
 		msg.Commit = m.Commit
-		assert.Equal(t, IsInitialMsg(msg), m.IsInitialMsg)
+		assert.Equal(t, m.IsInitialMsg, IsInitialMsg(msg))
 	}
 }
 
@@ -83,7 +83,7 @@ func TestEpochStale(t *testing.T) {
 		checkEpoch := new(metapb.RegionEpoch)
 		checkEpoch.Version = e.Version
 		checkEpoch.ConfVer = e.ConfVer
-		assert.Equal(t, IsEpochStale(epoch, checkEpoch), e.IsStale)
+		assert.Equal(t, e.IsStale, IsEpochStale(epoch, checkEpoch))
 	}
 }
 

--- a/kv/server/server_test.go
+++ b/kv/server/server_test.go
@@ -183,8 +183,8 @@ func TestRawDelete1(t *testing.T) {
 	assert.Nil(t, err)
 
 	val, err := Get(s, cf, []byte{99})
-	assert.Equal(t, err, nil)
-	assert.Equal(t, val, []byte(nil))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, []byte(nil), val)
 }
 
 func TestRawScan1(t *testing.T) {
@@ -286,7 +286,7 @@ func TestRawScanAfterRawDelete1(t *testing.T) {
 
 	resp, err := server.RawScan(nil, scan)
 	assert.Nil(t, err)
-	assert.Equal(t, len(resp.Kvs), len(expectedKeys))
+	assert.Equal(t, len(expectedKeys), len(resp.Kvs))
 	for i, kv := range resp.Kvs {
 		assert.Equal(t, expectedKeys[i], kv.Key)
 		assert.Equal(t, append([]byte{233}, expectedKeys[i]...), kv.Value)

--- a/kv/transaction/commands4b_test.go
+++ b/kv/transaction/commands4b_test.go
@@ -279,7 +279,7 @@ func TestPrewriteLocked4B(t *testing.T) {
 
 	assert.Empty(t, resps[0].(*kvrpcpb.PrewriteResponse).Errors)
 	assert.Nil(t, resps[0].(*kvrpcpb.PrewriteResponse).RegionError)
-	assert.Equal(t, len(resps[1].(*kvrpcpb.PrewriteResponse).Errors), 1)
+	assert.Equal(t, 1, len(resps[1].(*kvrpcpb.PrewriteResponse).Errors))
 	assert.Nil(t, resps[1].(*kvrpcpb.PrewriteResponse).RegionError)
 	builder.assertLens(1, 1, 0)
 	builder.assert([]kv{


### PR DESCRIPTION
### Code Changes
https://godoc.org/github.com/stretchr/testify/assert#Equal
based on signature of `func Equal(t TestingT, expected, actual)`, fix a few test lines to correct order. Else it may be confusing when test fail.

before
```
# assert.Equal(t, err, nil)
expected: error
actual: nil
```
after
```
# assert.Equal(t, nil, err)
expected: nil
actual: error
```

### Checked Folder (follow commit history ordering)
- [x] kv/server
- [x] kv/raftstore, kv/test_raftstore
- [x] kv/transaction

didn't find `assert.Equal` usage in other `kv` folders and `raft, scheduler` folder