### PR TITLE
Address issues with KeyError and MemStorage

### DIFF
--- a/kv/transaction/commands/scan.go
+++ b/kv/transaction/commands/scan.go
@@ -38,17 +38,14 @@ func (s *Scan) Read(txn *mvcc.RoTxn) (interface{}, [][]byte, error) {
 		key, value, err := scanner.Next()
 		if err != nil {
 			// Key error (e.g., key is locked) is saved as an error in the scan for the client to handle.
-			if e, ok := err.(*kvrpcpb.KeyError); ok {
+			if e, ok := err.(*mvcc.KeyError); ok {
 				pair := new(kvrpcpb.KvPair)
-				pair.Error = e
+				pair.Error = &e.KeyError
 				response.Pairs = append(response.Pairs, pair)
 				continue
-			} else if e, ok := err.(error); ok {
-				// Any other kind of error, we can't handle so quit the scan.
-				return nil, nil, e
 			} else {
-				// No way we should get here.
-				panic("unreachable")
+				// Any other kind of error, we can't handle so quit the scan.
+				return nil, nil, err
 			}
 		}
 		if key == nil {

--- a/kv/transaction/mvcc/scanner.go
+++ b/kv/transaction/mvcc/scanner.go
@@ -28,7 +28,7 @@ func (scan *Scanner) Close() {
 }
 
 // Next returns the next key/value pair from the scanner. If the scanner is exhausted, then it will return `nil, nil, nil`.
-func (scan *Scanner) Next() ([]byte, []byte, interface{}) {
+func (scan *Scanner) Next() ([]byte, []byte, error) {
 	// Search for the next relevant key/value.
 	for {
 		if !scan.writeIter.Valid() {
@@ -52,7 +52,7 @@ func (scan *Scanner) Next() ([]byte, []byte, interface{}) {
 		}
 		if lock != nil && lock.Ts < scan.txn.StartTS {
 			// The key is currently locked.
-			keyError := new(kvrpcpb.KeyError)
+			keyError := new(KeyError)
 			keyError.Locked = lock.Info(userKey)
 			return nil, nil, keyError
 		}
@@ -80,4 +80,13 @@ func (scan *Scanner) Next() ([]byte, []byte, interface{}) {
 
 		return userKey, value, nil
 	}
+}
+
+// KeyError is a wrapper type so we can implement the `error` interface.
+type KeyError struct {
+	kvrpcpb.KeyError
+}
+
+func (ke *KeyError) Error() string {
+	return ke.String()
 }


### PR DESCRIPTION
Implements `error` for `KeyError` and adds checking for unclosed iterators to `MemStorage`.

PTAL @Connor1996 